### PR TITLE
Update Dockerfile

### DIFF
--- a/fesom2_test_refactoring/Dockerfile
+++ b/fesom2_test_refactoring/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
     && apt-get update \
     && apt-get -y install make gfortran gcc g++ libblas-dev libopenmpi-dev \
     && apt-get -y install cmake vim git git-lfs libnetcdf-dev libnetcdff-dev libpmi2-pmix \
-    && apt-get -y install wget
+    && apt-get -y install wget \
+    && apt-get -y install nco cdo
 
 WORKDIR /fesom/
 


### PR DESCRIPTION
Allows some common checking utilities (mostly just for `ncdump`) in the Docker container.

Likely this will need a new upload to Dockerhub, not sure about that. But, if you change metadata a la `ncdump -h <file>`, it would be nice to do that without needing to log off from the container first.

The container gets minimally larger; but let's assume disk space for mini tests isn't going to be the bottleneck 😄 