### PR TITLE
fesom2_test_refactoring: pin setuptools<80 to keep pkg_resources for mkfesom

### DIFF
--- a/fesom2_test_refactoring/Dockerfile
+++ b/fesom2_test_refactoring/Dockerfile
@@ -26,7 +26,11 @@ RUN wget \
 
 RUN git clone https://github.com/FESOM/mkfesom.git
 WORKDIR /fesom/mkfesom/
-RUN pip install -e .
+# setuptools 80 dropped the bundled pkg_resources module by default, but
+# mkfesom's mkrun.py still does `import pkg_resources`. Pin to a version
+# that still exposes it until mkfesom is migrated to importlib.resources.
+RUN pip install 'setuptools<80' \
+  && pip install -e .
 WORKDIR /fesom/
 RUN mkdir results
 


### PR DESCRIPTION
## Summary

Re-enabling `docker-publish.yml` from its 60-day inactivity disable rebuilt all four images, and the new `fesom2_test_refactoring-master` picked up setuptools 80+ which dropped the bundled `pkg_resources` module. mkfesom's `mkrun.py` still does `import pkg_resources`, so every workflow that uses this image (recom, cavities, channel, icebergs, openmp, neverworld2, …) now crashes immediately:

```
File "/fesom/mkfesom/mkfesom/mkrun.py", line 10, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Pin setuptools to `<80` right before the mkfesom `pip install -e .` so `pkg_resources` is still available. The proper long-term fix is to migrate mkfesom to `importlib.resources`, but that's an mkfesom-side change.
