### PR TITLE
xios: null-guard CXios::globalRegistry deref in CContext::finalize (attached-mode SIGSEGV)

### DIFF
--- a/fesom2_ci/xios/src/node/context.cpp
+++ b/fesom2_ci/xios/src/node/context.cpp
@@ -494,7 +494,7 @@ namespace xios {
          {
            closeAllFile();
            registryOut->hierarchicalGatherRegistry() ;
-           if (server->intraCommRank==0) CXios::globalRegistry->mergeRegistry(*registryOut) ;
+           if (server->intraCommRank==0 && CXios::globalRegistry) CXios::globalRegistry->mergeRegistry(*registryOut) ;
          }
 
          //! Deallocate client buffers
@@ -534,7 +534,7 @@ namespace xios {
          if (hasServer && !hasClient)
          {           
            registryOut->hierarchicalGatherRegistry() ;
-           if (server->intraCommRank==0) CXios::globalRegistry->mergeRegistry(*registryOut) ;
+           if (server->intraCommRank==0 && CXios::globalRegistry) CXios::globalRegistry->mergeRegistry(*registryOut) ;
          }
 
          //! Deallocate client buffers

--- a/fesom2_test_refactoring/xios/src/node/context.cpp
+++ b/fesom2_test_refactoring/xios/src/node/context.cpp
@@ -494,7 +494,7 @@ namespace xios {
          {
            closeAllFile();
            registryOut->hierarchicalGatherRegistry() ;
-           if (server->intraCommRank==0) CXios::globalRegistry->mergeRegistry(*registryOut) ;
+           if (server->intraCommRank==0 && CXios::globalRegistry) CXios::globalRegistry->mergeRegistry(*registryOut) ;
          }
 
          //! Deallocate client buffers
@@ -534,7 +534,7 @@ namespace xios {
          if (hasServer && !hasClient)
          {           
            registryOut->hierarchicalGatherRegistry() ;
-           if (server->intraCommRank==0) CXios::globalRegistry->mergeRegistry(*registryOut) ;
+           if (server->intraCommRank==0 && CXios::globalRegistry) CXios::globalRegistry->mergeRegistry(*registryOut) ;
          }
 
          //! Deallocate client buffers


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV at `xios_context_finalize` for FESOM_WITH_XIOS=ON runs in attached mode (`using_server=false`), discovered while bringing up the new `fesom2_xios.yml` CI run-test on FESOM/fesom2.

In `src/node/context.cpp`'s `CContext::finalize`, the "Mode attache" branch dereferences `CXios::globalRegistry` unconditionally:

```cpp
if (server->intraCommRank==0) CXios::globalRegistry->mergeRegistry(*registryOut) ;
```

`CXios::globalRegistry` is only allocated on client rank 0 (`cxios.cpp:112`) but the merge is gated on `server->intraCommRank==0`; in attached mode those two ranks need not coincide, so a non-rank-0 process hits the deref on a null pointer and SIGSEGVs in `xios::CRegistry::mergeRegistry`. Files were already flushed by `closeAllFile()` earlier in the same branch, so the crash leaves the model output intact but the process exits with status 139.

The fix is a one-token addition of a null check; the patched line is equivalent for server mode (`globalRegistry` is always non-null on the server's rank 0) and lets attached-mode runs exit cleanly. Applied to both `fesom2_ci/xios/` and `fesom2_test_refactoring/xios/` source trees.

## Test plan

- [x] Verified locally on Levante (intel-oneapi-compilers/2022.0.1 + openmpi/4.1.2 + netcdf-c/4.8.1, 2-rank pi mesh, 6 XIOS-output fields sst/a_ice/temp/salt/u/v): without patch the run produces all 6 netcdf files but exits 139 with `Caught signal 11` in `xios::CRegistry::mergeRegistry`; with patch the run produces the same 6 netcdf files and exits cleanly with `fesom should stop with exit status = 0`.
- [ ] `docker-publish.yml` rebuilds both `fesom2_ci-master` and `fesom2_test_refactoring-master`.
- [ ] FESOM/fesom2 PR #902's `fesom2_xios.yml` workflow passes end-to-end against the new images.

## Notes

- The patch is identical to one carried in some downstream XIOS forks. We could upstream it to the IPSL XIOS svn separately.
- `fesom2_ci/xios/` and `fesom2_test_refactoring/xios/` carry duplicated source today (per the note in #5). A future cleanup that moves the XIOS source to a shared repo-root `_shared/xios/` will collapse this two-file change to one.